### PR TITLE
mod: do not reset forms when TransactionConfirm modal is closed by user

### DIFF
--- a/app/actions/MarketsActions.js
+++ b/app/actions/MarketsActions.js
@@ -582,7 +582,7 @@ class MarketsActions {
 				return true;
 			})
 			.catch((error) => {
-				console.log('order error:', error);
+				console.error('Process Transaction Error:', error);
 				return {error};
 			});
 	}

--- a/app/actions/TransactionConfirmActions.js
+++ b/app/actions/TransactionConfirmActions.js
@@ -67,7 +67,7 @@ class TransactionConfirmActions {
 	}
 
 	close(reject) {
-		reject();
+		reject({closed: true});
 		ZfApi.publish('transaction_confirm_actions', 'close');
 		return true;
 	}

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -1177,14 +1177,17 @@ class Exchange extends React.Component {
 		return MarketsActions.createLimitOrder2(limitOrders)
 			.then((result) => {
 				if (result.error) {
-					if (result.error.message !== 'wallet locked') {
+					if (
+						result.error.message === 'transaction confirm modal is closed' ||
+						result.error.message === 'wallet locked'
+					) {
+						return Promise.reject({error: result.error.message});
+					} else {
 						notification.error({
 							message: counterpart.translate(
 								'notifications.exchange_unknown_error_place_scaled_order'
 							),
 						});
-					} else {
-						return Promise.reject({error: result.error.message});
 					}
 				}
 			})
@@ -1236,7 +1239,12 @@ class Exchange extends React.Component {
 		return MarketsActions.createLimitOrder2(order)
 			.then((result) => {
 				if (result.error) {
-					if (result.error.message !== 'wallet locked') {
+					if (
+						result.error.message === 'transaction confirm modal is closed' ||
+						result.error.message === 'wallet locked'
+					) {
+						return Promise.reject({error: result.error.message});
+					} else {
 						console.log(result.error);
 						notification.error({
 							message: counterpart.translate(
@@ -1249,8 +1257,6 @@ class Exchange extends React.Component {
 								}
 							),
 						});
-					} else {
-						return Promise.reject({error: result.error.message});
 					}
 				} else {
 					this._clearForms(type === 'sell' ? 'ask' : 'bid');

--- a/app/stores/TransactionConfirmStore.js
+++ b/app/stores/TransactionConfirmStore.js
@@ -43,6 +43,7 @@ class TransactionConfirmStore {
 	onClose() {
 		//console.log("-- TransactionConfirmStore.onClose -->", state);
 		this.setState({closed: true});
+		this.state.reject({closed: true});
 	}
 
 	onBroadcast(payload) {

--- a/app/stores/WalletDb.js
+++ b/app/stores/WalletDb.js
@@ -234,15 +234,22 @@ class WalletDb extends BaseStore {
 						.then(() => {
 							if (broadcast) {
 								if (this.confirm_transactions) {
-									let p = new Promise((resolve, reject) => {
+									const transactionConfirmPromise = new Promise((resolve, reject) => {
 										TransactionConfirmActions.confirm(tr, resolve, reject);
 									});
-									return p.then(async () => {
-										await Axios.post(
-											process.env.LITE_WALLET_URL + '/saveBalance',
-											{accountName: AccountStore.getState().currentAccount}
-										);
-									});
+									return transactionConfirmPromise
+										.then(async () => {
+											await Axios.post(
+												process.env.LITE_WALLET_URL + '/saveBalance',
+												{accountName: AccountStore.getState().currentAccount}
+											);
+										})
+										.catch((e) => {
+											if (e && e.hasOwnProperty('closed') && e['closed']) {
+												console.error("TransactionConfirm Error:", e);
+												throw new Error('transaction confirm modal is closed');
+											}
+										});
 								} else return tr.broadcast();
 							} else return tr.serialize();
 						});
@@ -251,6 +258,8 @@ class WalletDb extends BaseStore {
 			.catch((e) => {
 				if (e.hasOwnProperty('isCanceled') && e['isCanceled']) {
 					throw new Error('wallet locked');
+				} else {
+					throw new Error(e.message);
 				}
 			})
 			.finally(() => {


### PR DESCRIPTION
<h2>General</h2>
Closes #[Insert issue number]

[Insert description of what you did, any description how to test or check your changes are welcome]

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at 
  - https://github.com/meta-source/meta-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/meta-source/meta-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [ ] Check for unused code
- [ ] No unrelated changes are included
- [ ] None of the changed files are reformatting only
- [ ] Code is self explanatory or documented
- [ ] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [ ] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [ ] Dark
- [ ] Light
- [ ] Midnight

_Please provide screenshots/licecap of your changes below_